### PR TITLE
update the header to fix menu position

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -13,7 +13,7 @@ function Header() {
 
     return (
         <BrowserRouter>
-            <header>
+            <header className='header'>
                 {/* Logo Section */}
                 <div className="nav-logo">
                     <Link to="/" className="logo">

--- a/src/styleHeader.css
+++ b/src/styleHeader.css
@@ -34,6 +34,8 @@ header {
     border-bottom: 2px solid var(--primary-purple);
     box-shadow: 0 4px 20px rgba(156, 39, 176, 0.3);
     font-family: 'Rajdhani', sans-serif;
+    display: flex;
+    align-items: center;
 }
 
 /* Navigation Container */
@@ -47,8 +49,6 @@ header {
 .nav-logo {
     display: flex;
     align-items: center;
-    padding: 15px 0;
-    margin-bottom: 10px;
     margin-left: 10px;
 }
 
@@ -94,6 +94,7 @@ header {
     font-weight: bold;
     text-transform: uppercase;
     letter-spacing: 2px;
+    white-space: nowrap;
 }
 
 /* Main Navigation */


### PR DESCRIPTION
## The issue:
The header with the logo was not in line with the rest of the menu.

## The solution:
I used `flex` for the header part to align it in a single row. I removed some padding and margin and replaced it with the `align-items: center` to center it in the middle of the row.

<details>
  <summary>
    <h3>Before</h3>
  </summary>
<img width="620" height="131" alt="Snímka obrazovky 2025-10-08 o 15 53 00" src="https://github.com/user-attachments/assets/8213ba06-a028-495e-b8b5-c186965bdd7d" />

</details>
<details>
  <summary>
    <h3>After</h3>
  </summary>
  <img width="661" height="130" alt="Snímka obrazovky 2025-10-08 o 15 53 58" src="https://github.com/user-attachments/assets/e6d7e47a-d370-4ce7-8b72-86ca4e1de295" />

</detials>